### PR TITLE
Add caveat for tap deprecation

### DIFF
--- a/Casks/espanso.rb
+++ b/Casks/espanso.rb
@@ -13,6 +13,17 @@ cask "espanso" do
   desc "A Privacy-first, Cross-platform Text Expander"
   homepage "https://espanso.org/"
 
+  caveats do
+    <<~EOS
+      This tap is deprecated in favor of the official homebrew-cask tap.
+
+      You can safely untap this tap with the following command:
+      brew untap espanso/espanso
+
+      For more details visit: https://espanso.org/docs/install/mac/
+    EOS
+  end
+
   app "Espanso.app"
 
   zap trash: "~/Library/Caches/espanso"


### PR DESCRIPTION
This adds a caveat to the formula that mentions this tap is deprecated in favor of the official homebrew-cask tap.

The message will be printed for a user when they install or update espanso via this tap.

I did not add an [official deprecation](https://docs.brew.sh/Deprecating-Disabling-and-Removing-Formulae#deprecation) but that could be done as well.

Relates to: https://github.com/espanso/website/pull/94